### PR TITLE
fix type error: Argument 2 passed to Invoice\Services\InvoiceLimitati…

### DIFF
--- a/src/Methods/InvoicePaymentMethod.php
+++ b/src/Methods/InvoicePaymentMethod.php
@@ -89,7 +89,7 @@ class InvoicePaymentMethod extends PaymentMethodService
         
         return $service->respectsAllLimitations(
             pluginApp(SettingsHelper::class, [$this->settings, $this->systemService->getPlentyId(), $this->session->getLang()]),
-            (INT) $this->checkout->getShippingCountryId(),
+            $this->checkout->getShippingCountryId() ?? 1,
             $isGuest,
             $basket->basketAmount,
             $basket->currency,

--- a/src/Methods/InvoicePaymentMethod.php
+++ b/src/Methods/InvoicePaymentMethod.php
@@ -89,7 +89,7 @@ class InvoicePaymentMethod extends PaymentMethodService
         
         return $service->respectsAllLimitations(
             pluginApp(SettingsHelper::class, [$this->settings, $this->systemService->getPlentyId()]),
-            $this->checkout->getShippingCountryId(),
+            (INT) $this->checkout->getShippingCountryId(),
             $isGuest,
             $basket->basketAmount,
             $basket->currency,
@@ -250,7 +250,7 @@ class InvoicePaymentMethod extends PaymentMethodService
             
             return $service->respectsAllLimitations(
                 pluginApp(SettingsHelper::class, [$this->settings, $this->systemService->getPlentyId()]),
-                $this->checkout->getShippingCountryId(),
+                (INT) $this->checkout->getShippingCountryId(),
                 $isGuest,
                 $basket->basketAmount,
                 $basket->currency,

--- a/src/Methods/InvoicePaymentMethod.php
+++ b/src/Methods/InvoicePaymentMethod.php
@@ -250,7 +250,7 @@ class InvoicePaymentMethod extends PaymentMethodService
             
             return $service->respectsAllLimitations(
                 pluginApp(SettingsHelper::class, [$this->settings, $this->systemService->getPlentyId(), $this->session->getLang()]),
-                (INT) $this->checkout->getShippingCountryId(),
+                $this->checkout->getShippingCountryId() ?? 1,
                 $isGuest,
                 $basket->basketAmount,
                 $basket->currency,


### PR DESCRIPTION
@plentymarkets/team-order-payment 

Problem:
"Type error: Argument 2 passed to Invoice\Services\InvoiceLimitationsService::respectsAllLimitations() must be of the type int, null given, called in plugins/sets/36/builds/c087281096ee7ba2cc6a6e684bf45ca7/Invoice/src/Methods/InvoicePaymentMethod.php on line 91

https://plentymarkets.kanbanize.com/ctrl_board/50/cards/98822/details/