### PR TITLE
fix the setting for identical addresses

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,8 +1,11 @@
 # Release Notes für Kauf auf Rechnung
 
-## 2.0.6 (2020-27-05)
+## 2.0.6 (2020-15-07)
 ### Geändert
 - Icon für das Backend hinzugefügt
+
+### Gefixt
+- Die Einstellung "Rechnungsadresse gleich Lieferadresse" wird nun korrekt angewendet.
 
 ## 2.0.5 (2020-04-03)
 ### Geändert

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,8 +1,11 @@
 # Release Notes for Invoice
 
-## 2.0.6 (2020-27-05)
+## 2.0.6 (2020-15-07)
 ### Changed
 - Added Icon for the backend
+
+### Fixed
+- The setting "Invoice address equals delivery address" is now applied correctly.
 
 ## 2.0.5 (2020-04-03)
 ### Changed

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-    "version"           : "2.0.5",
+    "version"           : "2.0.6",
     "name"              : "Invoice",
     "marketplaceName"   : {"de":"Kauf auf Rechnung","en":"Invoice"},
     "license"           : "AGPL-3.0",

--- a/src/Services/InvoiceLimitationsService.php
+++ b/src/Services/InvoiceLimitationsService.php
@@ -59,8 +59,7 @@ class InvoiceLimitationsService
         }
         
         //  Third: Check the addresses
-        //         Addresses are equal when: $deliveryAddressId === null || $billingAddressId === $deliveryAddressId
-        if($settingsHelper->shouldHaveIdenticalAddresses() && $deliveryAddressId !== null && $billingAddressId !== $deliveryAddressId) {
+        if($settingsHelper->shouldHaveIdenticalAddresses() && $deliveryAddressId > 0 && $billingAddressId !== $deliveryAddressId) {
             return false;
         }
         


### PR DESCRIPTION
`$deliveryAddressId` ist 0, nicht `null`, wenn die Lieferadresse gleich der Rechnungsadresse ist. Somit hatte die IF Bedingung hier nicht funktioniert.

https://plentymarkets.kanbanize.com/ctrl_board/50/cards/118908/details/

@plentymarkets/team-order-payment 